### PR TITLE
Prevent stacking of trinkets, weapons, and forged rings

### DIFF
--- a/StackEverythingRedux/ModConfig.cs
+++ b/StackEverythingRedux/ModConfig.cs
@@ -35,7 +35,15 @@ namespace StackEverythingRedux
         /// <summary>Items that should not stack.</summary>
         internal static HashSet<string> NoStackQualifiedIds { get; set; } =
         [
-            "(F)FreeCactus"
+            "(F)FreeCactus",        // Free Cactus
+            "(TR)BasiliskPaw",      // Trinkets
+            "(TR)FairyBox",
+            "(TR)FrogEgg",
+            "(TR)GoldenSpur",
+            "(TR)IceRod",
+            "(TR)MagicHairGel",
+            "(TR)MagicQuiver",
+            "(TR)ParrotEgg"
         ];
     }
 }

--- a/StackEverythingRedux/ModConfig.cs
+++ b/StackEverythingRedux/ModConfig.cs
@@ -35,15 +35,32 @@ namespace StackEverythingRedux
         /// <summary>Items that should not stack.</summary>
         internal static HashSet<string> NoStackQualifiedIds { get; set; } =
         [
-            "(F)FreeCactus",        // Free Cactus
-            "(TR)BasiliskPaw",      // Trinkets
+            // Free Cactus
+            "(F)FreeCactus",
+
+            // Trinkets
+            "(TR)BasiliskPaw",
             "(TR)FairyBox",
             "(TR)FrogEgg",
             "(TR)GoldenSpur",
             "(TR)IceRod",
             "(TR)MagicHairGel",
             "(TR)MagicQuiver",
-            "(TR)ParrotEgg"
+            "(TR)ParrotEgg",
+
+            // Weapons
+            "(W)4", // Galaxy Sword
+            "(W)23", // Galaxy Dagger
+            "(W)29", // Galaxy Hammer
+            "(W)61", // Iridium Needle
+            "(W)62", // Infinity Blade
+            "(W)63", // Infinity Gavel
+            "(W)64", // Infinity Dagger
+            "(W)65", // Meowmere
+            "(W)66",  // Iridium Scythe
+
+            // Forged rings
+            "(O)880"
         ];
     }
 }


### PR DESCRIPTION
This change would expand the list of items that cannot be stacked from just the Free Cactus to include a handful of additional items where stacking is actively harmful:

- Forged rings -> because they share an item ID, stacking forged rings turns them into the same combination (e.g., if you stack an iridium band + lucky ring on top of an iridium band + crabshell ring, you get 2x iridium band + crabshell ring)
- Trinkets -> stacking them together loses differences between items, most notably meaning that you can't collect different colors of frog eggs
- Weapons -> stacking weapons with different enchantments means you lose the different enchantments